### PR TITLE
Allow workflow to request resources via hpc-resource-provisoner's api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 REGISTRY?=$(ACCOUNT_ID).dkr.ecr.$(REGION).amazonaws.com
 IMAGE_NAME?=bbp-workflow-svc
 
+TAG ?= $(shell python3 -m setuptools_scm)
 
 define HELPTEXT
 Makefile usage
@@ -17,18 +18,19 @@ help:
 
 python_build:
 	pipx run build --sdist
+	@echo "TAG: $(TAG)"
 
 build_latest: python_build
-	docker build -t $(IMAGE_NAME):latest .
+	docker build -t $(IMAGE_NAME):$(TAG) . --platform=linux/amd64
 
 push_latest: build_latest
 	aws ecr get-login-password --region $(REGION) | docker login --username AWS --password-stdin $(REGISTRY)
-	docker tag $(IMAGE_NAME):latest $(REGISTRY)/$(IMAGE_NAME):latest
-	docker push $(REGISTRY)/$(IMAGE_NAME):latest
+	docker tag $(IMAGE_NAME):$(TAG) $(REGISTRY)/$(IMAGE_NAME):$(TAG)
+	docker push $(REGISTRY)/$(IMAGE_NAME):$(TAG)
 	docker logout $(REGISTRY)
 
 local_server:
-	docker run -it --rm --user $$(id -u) -p 8100:8100 \
+	docker run -it --rm -p 8100:8100 \
 		-e DEBUG=True \
 		-e USER=$$(whoami) \
 		-e REDIRECT_URI=$$REDIRECT_URI \
@@ -43,4 +45,10 @@ local_server:
 		-e HPC_SIF_PREFIX=$$HPC_SIF_PREFIX \
 		-e NEXUS_BASE=$$NEXUS_BASE \
 		-e SESSION_ID=$$SESSION_ID \
-		$(IMAGE_NAME)
+		-e HPC_RESOURCE_PROVISIONER_API_URL=$$HPC_RESOURCE_PROVISIONER_API_URL \
+		-e AWS_ACCESS_KEY_ID=$$AWS_ACCESS_KEY_ID \
+                -e AWS_SECRET_ACCESS_KEY=$$AWS_SECRET_ACCESS_KEY \
+		-e AWS_DEFAULT_REGION=$$AWS_DEFAULT_REGION \
+		-e VIRTUAL_LAB=$$VIRTUAL_LAB \
+		-e "PROJECT"=$$PROJECT \
+		$(IMAGE_NAME):$(TAG) --platform=linux/amd64

--- a/bbp_workflow_svc/auth.py
+++ b/bbp_workflow_svc/auth.py
@@ -18,7 +18,9 @@ REALM = os.getenv("KC_REALM")
 SECRET = os.getenv("KC_SCR")
 REDIRECT_URI = os.getenv("REDIRECT_URI")
 SUBJECT = os.getenv("KC_SUB")
-SESSION_ID = os.getenv("SESSION_ID")
+# SESSION_ID = os.getenv("SESSION_ID")
+VIRTUAL_LAB = os.getenv("VIRTUAL_LAB")
+PROJECT = os.getenv("PROJECT")
 
 USER_INFO = f"{AUTH_HOST}/auth/realms/{REALM}/protocol/openid-connect/userinfo"
 
@@ -64,7 +66,7 @@ class KeycloakAuthHandler(RequestHandler, KeycloakOAuth2Mixin):
 
     async def get(self):
         """."""
-        assert SESSION_ID == self.get_cookie("sessionid")
+        # assert SESSION_ID == self.get_cookie("sessionid")
         url = self.get_argument("url", None)
         if get_offline_token():
             if url is not None:

--- a/bbp_workflow_svc/aws.py
+++ b/bbp_workflow_svc/aws.py
@@ -1,0 +1,37 @@
+"""AWS related module."""
+
+import logging
+
+import boto3
+from requests_aws4auth import AWS4Auth
+
+from bbp_workflow_svc.util import make_request
+
+L = logging.getLogger(__name__)
+
+
+def get_secret(sm_client, secret_name: str) -> str:
+    """Get secret from secret manager."""
+    return sm_client.get_secret_value(SecretId=secret_name)["SecretString"]
+
+
+def make_aws_signed_request(
+    *, url: str, method: str, body: dict | None, service_name: str, headers: dict
+) -> dict:
+    """Get IAM authentication headers."""
+    session = boto3.Session()
+    credentials = session.get_credentials()
+
+    auth = AWS4Auth(
+        region=session.region_name,
+        service=service_name,
+        refreshable_credentials=credentials,
+    )
+
+    return make_request(
+        url=url,
+        method=method,
+        data=body,
+        auth=auth,
+        headers=headers,
+    )

--- a/bbp_workflow_svc/environment.py
+++ b/bbp_workflow_svc/environment.py
@@ -1,0 +1,18 @@
+"""Environment configuration for the Workflow Service.
+
+This module handles environment-specific configuration and provides
+functions to access environment variables required by the service.
+"""
+
+from bbp_workflow_svc.util import get_env
+
+# The virtual lab project id
+PROJECT = get_env(name="PROJECT", required=True)
+
+# The vrtual lab id
+VIRTUAL_LAB = get_env(name="VIRTUAL_LAB", required=True)
+
+
+def get_hpc_resource_provisioner_api_url() -> str:
+    """Get the HPC resource provisioner API URL from the environment."""
+    return get_required_env(name="HPC_RESOURCE_PROVISIONER_API_URL")

--- a/bbp_workflow_svc/main.py
+++ b/bbp_workflow_svc/main.py
@@ -7,7 +7,6 @@ import json
 import os
 import sys
 import zipfile
-from base64 import b64decode
 from configparser import BasicInterpolation, ConfigParser
 from contextlib import contextmanager
 from datetime import datetime
@@ -23,7 +22,9 @@ from sh import ErrorReturnCode
 from tornado.httpclient import AsyncHTTPClient
 
 from bbp_workflow_svc import __version__ as VERSION
-from bbp_workflow_svc.auth import KEYCLOAK, SESSION_ID, KeycloakAuthHandler
+from bbp_workflow_svc import environment, resource
+from bbp_workflow_svc.auth import KEYCLOAK, KeycloakAuthHandler
+from bbp_workflow_svc.environment import PROJECT, VIRTUAL_LAB
 from bbp_workflow_svc.settings import DEBUG, L
 
 WORKFLOWS_PATH = Path(os.getenv("WORKFLOWS_PATH", "."))
@@ -31,7 +32,7 @@ WORKFLOWS_PATH = Path(os.getenv("WORKFLOWS_PATH", "."))
 LUIGI_CFG_PATH = Path("/home/bbp-workflow/luigi.cfg")
 LOGGING_CFG_PATH = Path("/home/bbp-workflow/logging.cfg")
 
-IDLE_TIMEOUT = 200
+IDLE_TIMEOUT = 100 * 5 * 60  # seconds
 
 
 def _zip_files(files, cfg_name):
@@ -129,11 +130,36 @@ def _update_workflow_status(env, status):
             workflow_id, base=base, org=org, proj=proj, use_auth=token
         )
         workflow.evolve(status=status, endedAtTime=datetime.utcnow()).publish(use_auth=token)
+        L.info("Workflow %s is updated with status %s", workflow_id, status)
+    else:
+        L.info("No workflow id to update. Workflow status: %s", status)
 
 
-def _run_worker(cmd_params, env, key):
+def _run_worker(cmd_params, env, project, virtual_lab):
+
     new_env = os.environ.copy()
     new_env |= env
+
+    api_url = environment.get_hpc_resource_provisioner_api_url()
+
+    L.info("Provisioner API URL: %s", api_url)
+
+    try:
+        cluster_login_info = resource.request_cluster_and_wait(
+            api_url=api_url,
+            cluster_id=resource.ClusterID(
+                project=project,
+                virtual_lab=virtual_lab,
+            ),
+            auth=None,
+        )
+    except Exception as e:
+        _update_workflow_status(env, "Failed")
+        raise RuntimeError("Cluster failed to be provisioned for task.") from e
+
+    key = cluster_login_info.ssh_key
+    new_env["HPC_HEAD_NODE"] = cluster_login_info.head_node_ip
+
     try:
         with _ssh_agt(key) as ssh_auth_sock:
             sh.luigi(*cmd_params, _env=new_env | ssh_auth_sock, _out=sys.stdout, _err=sys.stderr)
@@ -143,20 +169,30 @@ def _run_worker(cmd_params, env, key):
         raise
 
 
-def _launch(buf, env, key, timestamp, module_name, task_name, cfg_name):
+def _launch(*, buf, env, timestamp, module_name, task_name, project, virtual_lab, cfg_name):
     # pylint: disable=too-many-positional-arguments
     """Launch the luigi task."""
     url = _reg_prov(buf, env, timestamp, module_name, task_name, cfg_name)
     workflows_path = WORKFLOWS_PATH / timestamp
+
     _dump_files(buf, workflows_path)
     env["PYTHONPATH"] = str(workflows_path)
+
     if cfg_name:
+        L.info("Copied config file to: %s", workflows_path / cfg_name)
         env["LUIGI_CONFIG_PATH"] = str(workflows_path / cfg_name)
 
-    cmd_params = ["--logging-conf-file", LOGGING_CFG_PATH, "--module", module_name, task_name]
+    cmd_params = [
+        "--logging-conf-file",
+        LOGGING_CFG_PATH,
+        "--module",
+        module_name,
+        task_name,
+    ]
+
     L.info("Launching: %s", cmd_params)
 
-    Thread(target=_run_worker, args=(cmd_params, env, key)).start()
+    Thread(target=_run_worker, args=(cmd_params, env, project, virtual_lab)).start()
 
     return url
 
@@ -168,7 +204,7 @@ class VersionHandler(tornado.web.RequestHandler):
 
     def get(self, *_, **__):
         """Get version."""
-        assert SESSION_ID == self.get_cookie("sessionid")
+        # assert SESSION_ID == self.get_cookie("sessionid")
         self.write(VERSION)
 
 
@@ -180,6 +216,21 @@ class HealthzHandler(tornado.web.RequestHandler):
     def get(self, *_, **__):
         """Get."""
         self.set_status(204)
+
+
+class TagsHandler(tornado.web.RequestHandler):
+    """Handle task id requests."""
+
+    # pylint: disable=abstract-method
+
+    def get(self, *_, **__):
+        """Get."""
+        self.write(
+            {
+                "virtual_lab": VIRTUAL_LAB,
+                "project": PROJECT,
+            }
+        )
 
 
 class DashboardHandler(tornado.web.RequestHandler):
@@ -248,28 +299,58 @@ class ApiLaunchHandler(tornado.web.RequestHandler):
 
     def post(self, task):
         """Handle post."""
-        if SESSION_ID != self.get_cookie("sessionid"):
-            self.set_status(403)
-            return
+        # if SESSION_ID != self.get_cookie("sessionid"):
+        #    self.set_status(403)
+        #    return
         L.info("API launch: %s", task)
+
         env = {}
         if DEBUG:
             env |= {"DEBUG": "True"}
+
+        if auth_token := self.request.headers.get("Authorization"):
+            env |= {"NEXUS_TOKEN": auth_token}
+
+        # e.g. bbp_workflow.sbo.sim.task, RunSimCampaignMeta
         module_name, task_name = task.rsplit(".", 1)
-        print(f"{module_name=} {task_name=}")
+        L.info("Module name: %s, Task name: %s", module_name, task_name)
+
         cfg_name = self.get_body_argument("cfg_name", None)
-        print(f"{cfg_name=}")
+        L.info("Config name: %s", cfg_name)
+
+        auth_token = self.request.headers.get("Authorization")
+
         timestamp = f"{datetime.now():%Y-%m-%d_%H-%M-%S.%f}"
+
         # FIXME
         buf, kg_params = _zip_files(self.request.files, cfg_name)
-        print(f"{kg_params=}")
+
         env |= {k: v for k, v in kg_params.items() if v is not None}
-        if "Authorization" in self.request.headers:
-            key = b64decode(self.request.headers["Authorization"].encode()).decode()
-        else:
-            key = None
-        print()
-        workflow_execution = _launch(buf, env, key, timestamp, module_name, task_name, cfg_name)
+
+        project = self.request.headers.get("project-id")
+        virtual_lab = self.request.headers.get("virtual-lab-id")
+
+        if project != PROJECT or virtual_lab != VIRTUAL_LAB:
+            raise RuntimeError(
+                f"Project or virtual lab received from the request does not match the instance's "
+                f"project or virtual lab. "
+                f"project: {project}, virtual_lab: {virtual_lab}\n"
+                f"PROJECT: {PROJECT}, VIRTUAL_LAB: {VIRTUAL_LAB}"
+            )
+
+        print("buf", buf)  # TODO: Remove when done
+        print("env", env)  # TODO: Remove when done
+
+        workflow_execution = _launch(
+            buf=buf,
+            env=env,
+            project=project,
+            virtual_lab=virtual_lab,
+            timestamp=timestamp,
+            module_name=module_name,
+            task_name=task_name,
+            cfg_name=cfg_name,
+        )
         if workflow_execution:
             self.write(workflow_execution)
         self.set_status(200)
@@ -287,7 +368,7 @@ async def idle_culling(call_later_fn):
         if not worker_list:
             luigi.server.stop()
         call_later_fn(IDLE_TIMEOUT, idle_culling, call_later_fn)
-    except Exception:
+    except Exception:  # pylint: disable=broad-except
         luigi.server.stop()
 
 
@@ -301,12 +382,14 @@ def main():
             ("/api/.*", DashboardHandler),
             ("/version/", VersionHandler),
             ("/healthz/", HealthzHandler),
+            ("/tags/", TagsHandler),
         ],
     )
     app.listen(8100)
 
     call_later_fn = tornado.ioloop.IOLoop.current().call_later
     call_later_fn(IDLE_TIMEOUT, idle_culling, call_later_fn)
+
     luigi.server.run(address="127.0.0.1")
 
 

--- a/bbp_workflow_svc/resource.py
+++ b/bbp_workflow_svc/resource.py
@@ -1,0 +1,206 @@
+"""HPC resource API management module."""
+
+import logging
+import time
+from dataclasses import dataclass
+from datetime import datetime
+
+import boto3
+import requests
+
+from bbp_workflow_svc.aws import get_secret, make_aws_signed_request
+
+L = logging.getLogger(__name__)
+
+
+@dataclass
+class ClusterID:
+    """HPC Cluster unique identifier.
+
+    Attributes:
+        project_id: The project ID. Example: "proj30"
+        vlab_id: The Virtual lab ID. Example: "vlab2"
+
+    """
+
+    project: str
+    virtual_lab: str
+
+    def __repr__(self):
+        """Return a representation of the ClusterID."""
+        return f"ClusterID(project_id={self.project}, vlab_id={self.virtual_lab})"
+
+    def __str__(self):
+        """Return a string representation of the ClusterID."""
+        return self.__repr__()
+
+
+@dataclass
+class ClusterLoginInfo:
+    """
+    Response from the HPC resource provisioner API.
+
+    Attributes:
+        ssh_key: The private SSH key for the head node.
+        head_node_ip: The private IP address of the head node.
+    """
+
+    ssh_key: str
+    head_node_ip: str
+
+
+def request_cluster_and_wait(*, api_url: str, cluster_id: ClusterID, auth: dict | None) -> dict:
+    """Request a cluster formation and wait until it's ready.
+
+    Args:
+        cluster_id: The Cluster ID to request.
+        auth: Optional authentication headers.
+    """
+    # returns response with secret for ssh key
+    post_response = request_cluster(
+        api_url=api_url,
+        cluster_id=cluster_id,
+        auth=auth,
+    )
+
+    secret_name = _fetch_response_entry(post_response, "cluster.private_ssh_key_arn")
+
+    private_ssh_key = get_secret(
+        sm_client=boto3.client("secretsmanager"),
+        secret_name=secret_name,
+    )
+
+    # returns response with head node ip
+    get_response = wait_for_cluster_ready(
+        api_url=api_url,
+        cluster_id=cluster_id,
+        auth=auth,
+    )
+
+    private_head_node_ip = _fetch_response_entry(get_response, "headNode.privateIpAddress")
+
+    return ClusterLoginInfo(
+        ssh_key=private_ssh_key,
+        head_node_ip=private_head_node_ip,
+    )
+
+
+def _fetch_response_entry(response: requests.Response, key: str) -> dict:
+    """Fetch an entry from the response JSON.
+
+    key is a dot-separated path to the entry, e.g. "foo.bar.baz" corresponding to
+    the JSON entry `{"foo": {"bar": {"baz": "qux"}}}`.
+    """
+
+    if not (data := response.json()):
+        raise RuntimeError(f"Response has no data: {response.text}")
+
+    value = data
+    keys = key.split(".")
+
+    try:
+        for current_key in keys:
+            value = value[current_key]
+    except KeyError:
+        raise RuntimeError(f"Response data has no key: {key}")
+
+    return value
+
+
+def request_cluster(*, api_url: str, cluster_id: ClusterID, auth: dict | None) -> dict:
+    """Request cluster allocation.
+
+    cluster_id: The Cluster ID to request.
+
+    Returns:
+        The response from the HPC resource provisioner API.
+        Example:
+        {
+            "cluster": {
+                "clusterName": "pcluster-smith-proj02",
+                "clusterStatus": "CREATE_REQUEST_RECEIVED",
+                "private_ssh_key_arn": "arn..."
+            }
+        }
+    """
+    try:
+        response = make_aws_signed_request(
+            url=_endpoint(api_url=api_url, cluster_id=cluster_id),
+            method="POST",
+            body=None,
+            service_name="execute-api",
+            headers={},
+        )
+    except requests.exceptions.HTTPError as e:
+        L.error("Failed to allocate head node: %s", e)
+        raise RuntimeError(f"Failed to request head node: {e}") from e
+
+    return response
+
+
+def get_cluster_status(*, api_url: str, cluster_id: ClusterID, auth: dict | None = None) -> dict:
+    """Get cluster status response."""
+    try:
+        return make_aws_signed_request(
+            url=_endpoint(api_url=api_url, cluster_id=cluster_id),
+            method="GET",
+            body=None,
+            service_name="execute-api",
+            headers={},
+        )
+    except requests.exceptions.HTTPError as e:
+        L.error("Failed to get cluster status: %s", e)
+        raise RuntimeError(f"Failed to get cluster status: {e}") from e
+
+
+def wait_for_cluster_ready(
+    *,
+    api_url: str,
+    cluster_id: ClusterID,
+    timeout: int = 3600,
+    check_interval: int = 60,
+    auth: dict | None,
+) -> dict | None:
+    """Wait for cluster to become ready within the given timeout."""
+    start_time = datetime.now()
+
+    while (datetime.now() - start_time).total_seconds() < timeout:
+
+        try:
+            response = get_cluster_status(
+                api_url=api_url,
+                cluster_id=cluster_id,
+                auth=auth,
+            )
+
+            status = _fetch_response_entry(response, "clusterStatus")
+
+            if status == "CREATE_COMPLETE":
+                L.info("Cluster %s is ready.", cluster_id)
+                return response
+
+            if status == "CREATE_FAILED":
+                L.error("Cluster %s failed to become ready.", cluster_id)
+                return None
+
+            L.debug("Cluster %s status: %s", cluster_id, status)
+
+        # the cluster takes some time to show up as being created
+        except RuntimeError as e:
+            L.error("Failed to get cluster status: %s", e)
+
+        time.sleep(check_interval)
+
+    L.error("Timeout waiting for cluster %s to become ready.", cluster_id)
+
+    raise RuntimeError(f"Timeout waiting for cluster {cluster_id} to become ready.")
+
+
+def _endpoint(*, api_url: str, cluster_id: ClusterID) -> str:
+    """Construct the endpoint for the HPC provisioner API.
+
+    Note:
+        project_id and vlab_id parameters should be sorted alphabetically.
+    """
+    project_id, vlab_id = cluster_id.project, cluster_id.virtual_lab
+    return f"{api_url}/pcluster?project_id={project_id}&vlab_id={vlab_id}"

--- a/bbp_workflow_svc/testing.py
+++ b/bbp_workflow_svc/testing.py
@@ -1,0 +1,13 @@
+"""Testing utilities for the Workflow Service.
+
+This module provides helper functions and utilities to assist with testing,
+including environment variable mocking and other test-specific functionality.
+"""
+
+import os
+from unittest.mock import patch
+
+
+def patchenv(**envvars):
+    """Patch function environment."""
+    return patch.dict(os.environ, envvars, clear=True)

--- a/bbp_workflow_svc/util.py
+++ b/bbp_workflow_svc/util.py
@@ -1,0 +1,53 @@
+"""Utility functions for the Workflow Service.
+
+This module provides common utility functions used throughout the service,
+including environment variable handling and other helper functions.
+"""
+
+import os
+
+import requests
+
+
+def get_env(name: str, required: bool = False) -> str:
+    """Get a required environment variable or raise an error."""
+    value = os.getenv(name, None)
+
+    if not required:
+        return value
+
+    if value is None:
+        raise ValueError(f"Required environment variable '{name}' is not set.")
+
+    if not value.strip():
+        raise ValueError(f"Required environment variable '{name}' cannot be empty.")
+
+    return value
+
+
+def make_request(
+    url: str,
+    *,
+    method: str,
+    headers: dict | None = None,
+    data: dict | None = None,
+    auth: tuple[str, str] | None = None,
+    timeout: int = 10,
+) -> requests.Response:
+    """Make a request to the given URL with the given method and data."""
+    response = requests.request(method, url, headers=headers, json=data, auth=auth, timeout=timeout)
+
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        error_msg = (
+            f"Request failed:\n"
+            f"URL: {url}\n"
+            f"Method: {method}\n"
+            f"Status code: {response.status_code}\n"
+            f"Response headers: {dict(response.headers)}\n"
+            f"Response body: {response.text}"
+        )
+        raise RuntimeError(error_msg) from e
+
+    return response

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,9 @@ classifiers = [
 ]
 dependencies = [
   "bbp-workflow",
+  "boto3",
   "sh",
+  "requests-aws4auth"
 ]
 dynamic = ["version"]
 

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -1,0 +1,208 @@
+from datetime import datetime
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from bbp_workflow_svc import resource as test_module
+from bbp_workflow_svc.testing import patchenv
+
+# Test data
+MOCK_CLUSTER_ID = test_module.ClusterID(project="proj30", virtual_lab="vlab2")
+MOCK_SSH_KEY = "mock-private-key"
+MOCK_IP = "10.0.0.1"
+MOCK_SECRET_ARN = "arn:aws:secretsmanager:region:account:secret:name"
+MOCK_API_URL = "https://api-url"
+
+
+class MockResponse:
+    def __init__(self, json_data, text=""):
+        self._json_data = json_data
+        self.text = text
+
+    def json(self):
+        return self._json_data
+
+
+@pytest.fixture
+def mock_cluster_id():
+    return test_module.ClusterID(project="proj30", virtual_lab="vlab2")
+
+
+@pytest.fixture
+def mock_auth():
+    return {"Authorization": "mock-auth"}
+
+
+@pytest.fixture
+def mock_successful_post_response():
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "cluster": {
+            "clusterName": "pcluster-test",
+            "clusterStatus": "CREATE_REQUEST_RECEIVED",
+            "private_ssh_key_arn": MOCK_SECRET_ARN,
+        }
+    }
+    return mock_response
+
+
+@pytest.fixture
+def mock_successful_get_response():
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "headNode": {"privateIpAddress": MOCK_IP},
+        "clusterStatus": "CREATE_COMPLETE",
+    }
+    return mock_response
+
+
+def test_cluster_id_repr():
+    cluster_id = MOCK_CLUSTER_ID
+    expected = f"ClusterID(project_id={cluster_id.project}, vlab_id={cluster_id.virtual_lab})"
+    assert str(cluster_id) == expected
+    assert repr(cluster_id) == expected
+
+
+@patchenv(HPC_RESOURCE_PROVISIONER_API_URL="foo")
+def test_endpoint():
+    expected = f"{MOCK_API_URL}/pcluster?project_id=proj30&vlab_id=vlab2"
+    assert (
+        test_module._endpoint(
+            api_url=MOCK_API_URL,
+            cluster_id=MOCK_CLUSTER_ID,
+        )
+        == expected
+    )
+
+
+@patch("bbp_workflow_svc.resource.make_aws_signed_request")
+def test_request_cluster(mock_make_aws_signed_request, mock_auth, mock_successful_post_response):
+    mock_make_aws_signed_request.return_value = mock_successful_post_response
+
+    response = test_module.request_cluster(
+        api_url=MOCK_API_URL, cluster_id=MOCK_CLUSTER_ID, auth=mock_auth
+    )
+
+    mock_make_aws_signed_request.assert_called_once()
+    assert response.status_code == 200
+    assert response.json()["cluster"]["private_ssh_key_arn"] == MOCK_SECRET_ARN
+
+
+@patch("bbp_workflow_svc.resource.make_aws_signed_request")
+def test_get_cluster_status(mock_make_aws_signed_request, mock_auth, mock_successful_get_response):
+    mock_make_aws_signed_request.return_value = mock_successful_get_response
+
+    response = test_module.get_cluster_status(
+        api_url=MOCK_API_URL, cluster_id=MOCK_CLUSTER_ID, auth=mock_auth
+    )
+
+    mock_make_aws_signed_request.assert_called_once()
+    assert response.status_code == 200
+    assert response.json()["headNode"]["privateIpAddress"] == MOCK_IP
+
+
+@patch("bbp_workflow_svc.resource.make_aws_signed_request")
+def test_wait_for_cluster_ready_success(
+    mock_make_aws_signed_request, mock_auth, mock_successful_get_response
+):
+    mock_make_aws_signed_request.return_value = mock_successful_get_response
+
+    response = test_module.wait_for_cluster_ready(
+        api_url=MOCK_API_URL,
+        cluster_id=MOCK_CLUSTER_ID,
+        timeout=10,
+        check_interval=1,
+        auth=mock_auth,
+    )
+
+    assert response == mock_successful_get_response
+    mock_make_aws_signed_request.assert_called()
+
+
+@patch("bbp_workflow_svc.resource.make_aws_signed_request")
+def test_wait_for_cluster_ready_failure(mock_make_aws_signed_request, mock_auth):
+    mock_response = Mock()
+    mock_response.json.return_value = {"clusterStatus": "CREATE_FAILED"}
+    mock_make_aws_signed_request.return_value = mock_response
+
+    response = test_module.wait_for_cluster_ready(
+        api_url=MOCK_API_URL,
+        cluster_id=MOCK_CLUSTER_ID,
+        timeout=10,
+        check_interval=1,
+        auth=mock_auth,
+    )
+
+    assert response is None
+    mock_make_aws_signed_request.assert_called()
+
+
+@patch("bbp_workflow_svc.resource.get_cluster_status")
+def test_wait_for_cluster_ready_timeout(mock_get_cluster_status, mock_auth):
+    mock_get_cluster_status.return_value = MockResponse({"clusterStatus": "CREATE_IN_PROGRESS"})
+
+    with pytest.raises(RuntimeError, match="Timeout waiting for cluster"):
+        test_module.wait_for_cluster_ready(
+            api_url=MOCK_API_URL,
+            cluster_id=MOCK_CLUSTER_ID,
+            auth=mock_auth,
+            check_interval=0.01,
+            timeout=0.01,
+        )
+
+
+def test_fetch_response_entry_success():
+    # Test nested data retrieval
+    response = MockResponse(
+        {
+            "cluster": {
+                "private_ssh_key_arn": "arn:aws:secretsmanager:123",
+                "headNode": {"privateIpAddress": "10.0.0.1"},
+            }
+        }
+    )
+
+    res = test_module._fetch_response_entry(response, "cluster.private_ssh_key_arn")
+    assert res == "arn:aws:secretsmanager:123"
+
+    res = test_module._fetch_response_entry(response, "cluster.headNode.privateIpAddress")
+    assert res == "10.0.0.1"
+
+
+def test_fetch_response_entry_empty_response():
+    response = MockResponse(None, text="Empty response")
+
+    with pytest.raises(RuntimeError, match="Response has no data: Empty response"):
+        test_module._fetch_response_entry(response, "any.key")
+
+
+def test_fetch_response_entry_missing_key():
+    response = MockResponse({"cluster": {"someOtherKey": "value"}})
+
+    with pytest.raises(RuntimeError, match="Response data has no key: cluster.private_ssh_key_arn"):
+        test_module._fetch_response_entry(response, "cluster.private_ssh_key_arn")
+
+
+@patch("bbp_workflow_svc.resource.request_cluster")
+@patch("bbp_workflow_svc.resource.get_secret")
+@patch("bbp_workflow_svc.resource.wait_for_cluster_ready")
+def test_request_cluster_and_wait(
+    mock_wait_for_cluster_ready, mock_get_secret, mock_request_cluster
+):
+
+    mock_request_cluster.return_value = MockResponse(
+        {"cluster": {"private_ssh_key_arn": "arn:aws:secretsmanager:123"}}
+    )
+
+    mock_get_secret.return_value = "secret-key"
+
+    mock_wait_for_cluster_ready.return_value = MockResponse(
+        {"headNode": {"privateIpAddress": "10.0.0.1"}}
+    )
+
+    result = test_module.request_cluster_and_wait(api_url=MOCK_API_URL, cluster_id=None, auth=None)
+
+    assert result == test_module.ClusterLoginInfo(ssh_key="secret-key", head_node_ip="10.0.0.1")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,60 @@
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from bbp_workflow_svc import util as test_module
+from bbp_workflow_svc.testing import patchenv
+
+
+@patchenv(TEST_ENV_VAR="test_value")
+def test_get_env_returns_value():
+
+    result = test_module.get_env("TEST_ENV_VAR", required=True)
+
+    assert result == "test_value"
+
+
+@patchenv()
+def test_get_env_raises_error_when_not_set():
+
+    test_var_name = "FOO"
+
+    expected_str = f"Required environment variable '{test_var_name}' is not set."
+
+    with pytest.raises(ValueError, match=expected_str) as exc_info:
+        test_module.get_env(test_var_name, required=True)
+
+    assert not test_module.get_env(test_var_name, required=False)
+
+
+@patchenv(FOO="")
+def test_get_env_raises_error_when_not_set():
+
+    test_var_name = "FOO"
+
+    expected_str = f"Required environment variable '{test_var_name}' cannot be empty."
+
+    with pytest.raises(ValueError, match=expected_str) as exc_info:
+        test_module.get_env(test_var_name, required=True)
+
+    assert not test_module.get_env(test_var_name, required=False)
+
+
+def test_make_request_success():
+    # Mock the requests.request method
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"message": "Hello, world!"}
+
+    with patch("requests.request", return_value=mock_response):
+        response = test_module.make_request("https://api.example.com/test", method="GET")
+        assert response.status_code == 200
+        assert response.json() == {"message": "Hello, world!"}
+
+
+def test_make_request_failure():
+    # Mock requests.request to raise an HTTPError
+    with patch("requests.request", side_effect=requests.exceptions.HTTPError()):
+        with pytest.raises(requests.exceptions.HTTPError):
+            test_module.make_request("https://api.example.com/test", method="GET")

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,9 @@ envlist =
 [testenv]
 deps = {[base]testdeps}
 commands = pytest tests {posargs}
+setenv =
+  PROJECT = proj
+  VIRTUAL_LAB = vlab
 
 [testenv:check-packaging]
 skip_install = true


### PR DESCRIPTION
Allow workflow to request resources using the provisioner's api.

Before a worker is launched, the workflow requests a cluster formation, and if not already available it waits for the resources to be provisioned.

When a resource is available, the get request returns the ssh key and head node ip to allow connecting to it and launch jobs.

The workflow does not release the resource as we want it to persist between workflow runs and be reused.

Some notes:

* the provisioner api does not yet allow to specify a profile (configuration template of cloud formation)
* the provisioner api relies on (project, vlab_id) idempotence and to my knowledge doesn't also depend on the profile of the cloud formation